### PR TITLE
Limit processing queue to 10k posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,10 @@ The Azure AI Content Safety API uses severity levels from 0-6:
 ## License
 
 This repository is licensed under the [Mattermost Source Available License](LICENSE) license.
+
+## Roadmap
+
+- [ ] Add local LLM option as the moderator backend
+- [ ] Support moderating text attachments
+- [ ] Support moderating images
+- [ ] Add metrics visualization support (Grafana)

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -6,9 +6,9 @@ import (
 )
 
 func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
-	p.processor.queuePostForProcessing(post)
+	p.processor.queuePostForProcessing(p.API, post)
 }
 
 func (p *Plugin) MessageHasBeenUpdated(c *plugin.Context, post, _ *model.Post) {
-	p.processor.queuePostForProcessing(post)
+	p.processor.queuePostForProcessing(p.API, post)
 }


### PR DESCRIPTION
With this change, we now limit the queue of posts to process to 10k posts. If we exceed that number, we won't moderate any additional posts and will log an error. In the future, we may make that number configurable if needed, but we don't currently have plans to do so.

Unrelated: I've also added a `Roadmap` section to the `README` for future features we have planned.