### PR TITLE
OnActivate should succeed when not configured

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -27,7 +27,7 @@
                 "display_name": "Enable Content Moderation",
                 "type": "bool",
                 "help_text": "When true, content moderation is enabled.",
-                "default": true
+                "default": false
             },
             {
                 "key": "type",

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -129,19 +129,19 @@ func (p *Plugin) setConfiguration(configuration *configuration) {
 
 // OnConfigurationChange is invoked when configuration changes may have been made.
 func (p *Plugin) OnConfigurationChange() error {
-	var configuration = new(configuration)
+	var config = new(configuration)
 
 	// Load the public configuration fields from the Mattermost server configuration.
-	if err := p.API.LoadPluginConfiguration(configuration); err != nil {
+	if err := p.API.LoadPluginConfiguration(config); err != nil {
 		return errors.Wrap(err, "failed to load plugin configuration")
 	}
 
-	p.setConfiguration(configuration)
+	p.setConfiguration(config)
 
 	// Initialize or reinitialize the moderator with the new configuration
-	if err := p.initialize(); err != nil {
+	if err := p.initialize(config); err != nil {
 		p.API.LogError("Failed to reinitialize after configuration change", "err", err)
-		return errors.Wrap(err, "failed to reinitialize")
+		return nil
 	}
 
 	return nil

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -6,9 +6,13 @@ import (
 )
 
 func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
-	p.processor.queuePostForProcessing(post)
+	if p.processor != nil {
+		p.processor.queuePostForProcessing(post)
+	}
 }
 
 func (p *Plugin) MessageHasBeenUpdated(c *plugin.Context, post, _ *model.Post) {
-	p.processor.queuePostForProcessing(post)
+	if p.processor != nil {
+		p.processor.queuePostForProcessing(post)
+	}
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -61,13 +61,14 @@ func (p *Plugin) OnActivate() error {
 }
 
 func (p *Plugin) initialize(config *configuration) error {
-	if !config.Enabled {
-		return nil
-	}
-
 	if p.processor != nil {
 		p.processor.stop()
 		p.processor = nil
+	}
+
+	if !config.Enabled {
+		p.API.LogInfo("Content moderation is disabled")
+		return nil
 	}
 
 	moderator, err := initModerator(p.API, config)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -31,12 +31,6 @@ type Plugin struct {
 }
 
 func (p *Plugin) OnActivate() error {
-	config := p.getConfiguration()
-	if !config.Enabled {
-		p.API.LogInfo("Content moderation is disabled")
-		return nil
-	}
-
 	if !pluginapi.IsEnterpriseLicensedOrDevelopment(
 		p.API.GetConfig(),
 		p.API.GetLicense(),
@@ -52,6 +46,7 @@ func (p *Plugin) OnActivate() error {
 	}
 	p.sqlStore = SQLStore
 
+	config := p.getConfiguration()
 	if err := p.initialize(config); err != nil {
 		p.API.LogError("Cannot initialize plugin", "err", err)
 		return nil

--- a/server/processor.go
+++ b/server/processor.go
@@ -149,7 +149,7 @@ func (p *PostProcessor) moderatePost(api plugin.API, post *model.Post) error {
 	}
 
 	if p.resultSeverityAboveThreshold(result) {
-		p.logFlaggedResult(api, post.UserId, result)
+		p.logFlaggedResult(api, post.Id, result)
 		return ErrModerationRejection
 	}
 
@@ -184,12 +184,12 @@ func (p *PostProcessor) resultSeverityAboveThreshold(result moderation.Result) b
 	return false
 }
 
-func (p *PostProcessor) logFlaggedResult(api plugin.API, userID string, result moderation.Result) {
-	keyPairs := []any{"user_id", userID, "threshold", p.thresholdValue}
+func (p *PostProcessor) logFlaggedResult(api plugin.API, postID string, result moderation.Result) {
+	keyPairs := []any{"post_id", postID, "severity_threshold", p.thresholdValue}
 
 	for category, severity := range result {
 		if severity >= p.thresholdValue {
-			keyPairs = append(keyPairs, category)
+			keyPairs = append(keyPairs, fmt.Sprintf("computed_severity_%s", category))
 			keyPairs = append(keyPairs, severity)
 		}
 	}

--- a/server/processor_test.go
+++ b/server/processor_test.go
@@ -379,7 +379,7 @@ func TestModeratePost(t *testing.T) {
 	t.Run("Content above threshold", func(t *testing.T) {
 		mockAPI := &plugintest.API{}
 		mockAPI.On("LogInfo", "Content was flagged by moderation",
-			"user_id", "user1", "threshold", 50, "sexual", 80).Return()
+			"post_id", "", "severity_threshold", 50, "computed_severity_sexual", 80).Return()
 
 		mockModerator := &MockModerator{}
 		mockModerator.On("ModerateText", mock.Anything, "Inappropriate content").


### PR DESCRIPTION
Previously, if the plugin was not configured, OnActivate would return an error. This would result in an error loop on the server where the plugin manager would continuously attempt to restart the plugin.

With this change, OnActivate will always return nil when the plugin is not fully configured, or if moderation is explicitly disabled.

If moderation _is_ enabled and the plugin is not fully configured, we still return nil; however, we will also log an error. This will help in the event that the configuration is inadvertently changed, and some required field is omitted.

This PR also has a small improvement to how we log moderated posts. We now include the ID of the moderated Post in the log, and we now use some better metadata key names. The log looks like:

```json
{
  "timestamp":"2025-06-17 10:44:07.321 -04:00",
  "level":"info",
  "msg":"Content was flagged by moderation",
  "caller":"app/plugin_api.go:1108",
  "plugin_id":"com.mattermost.content-moderation",
  "post_id":"i9rbgbdnn7f38ke8r9hz8ww7yo",
  "severity_threshold":"2",
  "computed_severity_Hate":"2",
  "computed_severity_Violence":"4"
}
```