### PR TITLE
Update Go to 1.24 and golangci-lint to v1.62.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ apply:
 ## Install go tools
 install-go-tools:
 	@echo Installing go tools
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
 	$(GO) install gotest.tools/gotestsum@v1.7.0
 
 ## Runs eslint and golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/mattermost/mattermost-plugin-content-moderation
 
-go 1.22.0
-
-toolchain go1.22.8
+go 1.24.0
 
 require (
 	github.com/Masterminds/squirrel v1.5.4


### PR DESCRIPTION
Mattermost is using 1.24 now: https://github.com/mattermost/mattermost/commit/e6d8bf5835b0862cd4225257f911bfcb440f9aed

This PR supports building the plugin with the 1.24 golang compiler.