### PR TITLE
Add Mattermost Agents Plugin as Content Moderation Backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,18 +5,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **IMPORTANT**: This CLAUDE.md file MUST be kept up to date whenever code changes are made, with NO EXCEPTIONS. Any changes to the codebase should be reflected in this document.
 
 ## Project Context
-This repository contains a Mattermost Content Moderation plugin that provides automatic content moderation using Azure AI Content Safety APIs. Key features:
+This repository contains a Mattermost Content Moderation plugin that provides automatic content moderation using multiple backend providers. Key features:
 
 - Text content moderation (hate speech, sexual, violence, self-harm)
+- Multiple moderation backends: Azure AI Content Safety and Agents Plugin (LLM)
 - Configurable single moderation threshold
 - User targeting (specific users or all users)
 - Plugin hooks for message posting and editing
-- Fail-closed approach for API failures
+- Fail-open approach for API failures
 - Integration with Mattermost AI Plugin
 
 The core components include:
 - `moderation/moderator.go`: Core moderation interface
 - `moderation/azure/azure.go`: Azure AI Content Safety implementation
+- `moderation/agents/agents.go`: Agents Plugin (LLM) implementation
 - `plugin.go`: Main plugin with hooks for message moderation
 - `configuration.go`: Plugin settings management
 
@@ -42,5 +44,8 @@ The core components include:
 - Use hooks defined in plugin.go for server-side integration
 - Maintain separation of concerns with modular organization
 - Plugin hooks for message interception (MessageWillBePosted, MessageWillBeUpdated)
-- Single moderator interface with Azure implementation
+- Single moderator interface with multiple backend implementations:
+  - Azure AI Content Safety
+  - Mattermost Agents Plugin
 - Configuration with a single threshold value instead of per-category thresholds
+- Backend selection via "type" configuration dropdown

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mattermost Content Moderation Plugin
 
-This plugin provides content moderation capabilities for Mattermost using Azure AI Content Safety APIs.
+This plugin provides content moderation capabilities for Mattermost using Azure AI Content Safety APIs or the Mattermost Agents Plugin.
 
 This plugin requires an active enterprise license of Mattermost.
 
@@ -18,7 +18,11 @@ Key features:
 1. Download the latest release from the [releases page](https://github.com/mattermost/mattermost-plugin-content-moderation/releases)
 2. Upload the plugin to your Mattermost instance via System Console > Plugin Management
 3. Enable the plugin
-4. Configure the plugin with your Azure AI Content Safety API key and settings
+4. Configure the plugin with your moderation backend and settings
+
+## Agents Plugin Setup
+
+To use the Agents Plugin as your moderation backend, install and configure the Mattermost Agents Plugin with an agent that has "Enable Tools" disabled and is accessible to all users. We recommend using Mistral as the LLM model for content moderation tasks.
 
 ## Configuration
 
@@ -27,17 +31,20 @@ Configuration options:
 | Setting | Description |
 |---------|-------------|
 | Enabled | Enable/disable content moderation |
-| Type | Moderation provider type (currently only "azure" is supported) |
-| Azure Endpoint | Azure API endpoint |
-| Azure API Key | Azure API key (kept secure) |
+| Type | Moderation provider type ("azure" or "agents") |
+| Azure Endpoint | Azure API endpoint (Azure backend only) |
+| Azure API Key | Azure API key (kept secure, Azure backend only) |
+| Agents System Prompt | Custom system prompt for LLM moderation (Agents backend only) |
+| Agents Bot Username | The username of the specific agent to use for content moderation. Leave empty to use the default agent (Agents backend only) |
 | Exclude Direct/Group Messages | When enabled, direct messages and group messages will not be moderated |
 | Exclude Private Channels | When enabled, private channels will not be moderated |
 | Excluded Users | User IDs to exclude from content moderation. All other users will be moderated |
 | Excluded Channels | Channel IDs to exclude from content moderation. Messages in these channels will not be moderated |
 | Bot Username | The username displayed for moderation notifications |
-| Azure Threshold | Single severity threshold applied to all content categories |
+| Azure Threshold | Single severity threshold applied to all content categories (Azure backend only) |
+| Agents Threshold | Single severity threshold applied to all content categories (Agents backend only) |
 
-The Azure AI Content Safety API uses severity levels from 0-6:
+Both backends use severity levels from 0-6:
 - 0: Safe (always allowed)
 - 2: Low severity (mild)
 - 4: Medium severity (moderate)
@@ -51,7 +58,7 @@ This repository is licensed under the [Mattermost Source Available License](LICE
 
 ### How does content moderation work?
 
-When a user posts a message, it appears immediately in the channel. The plugin then analyzes the content in the background using Azure AI Content Safety APIs. If harmful content is detected, the post is automatically deleted and notifications are sent to inform users of the removal.
+When a user posts a message, it appears immediately in the channel. The plugin then analyzes the content in the background using the configured moderation backend. If harmful content is detected, the post is automatically deleted and notifications are sent to inform users of the removal.
 
 ### Will I still receive notifications for harmful content?
 
@@ -119,8 +126,8 @@ The plugin implements a dual-processor architecture with asynchronous content an
 │              │                  │    │                      │                      │
 │              ▼                  │    │                      ▼                      │
 │  ┌─────────────────────────────┐│    │  ┌─────────────────────────────────────────┐│
-│  │      Azure AI Content      ││    │  │       Wait for Results                  ││
-│  │       Safety API            ││    │  │                                         ││
+│  │    Moderation Backend       ││    │  │       Wait for Results                  ││
+│  │                             ││    │  │                                         ││
 │  │                             ││    │  │  Waits for moderation analysis          ││
 │  │  Analyzes content across    ││    │  │  to complete before taking action       ││
 │  │  multiple categories and    ││    │  │                                         ││
@@ -157,7 +164,7 @@ The plugin implements a dual-processor architecture with asynchronous content an
 
 - [ ] Implement notification blocking for posts under moderation
 - [X] Support writing moderation events to the Audit log
-- [ ] Add local LLM option as the moderator backend
+- [X] Add local LLM option as the moderator backend
 - [ ] Support excluding users from moderation by group
 - [ ] Support moderating text attachments
 - [ ] Support moderating images

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.24.4
 
 require (
 	github.com/gorilla/mux v1.8.1
+	github.com/mattermost/mattermost-plugin-ai v1.3.0
 	github.com/mattermost/mattermost/server/public v0.1.16-0.20250626003732-aaa62a40ae86
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956 h1:Y1Tu/swM31pVwwb
 github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956/go.mod h1:SRl30Lb7/QoYyohYeVBuqYvvmXSZJxZgiV3Zf6VbxjI=
 github.com/mattermost/logr/v2 v2.0.22 h1:npFkXlkAWR9J8payh8ftPcCZvLbHSI125mAM5/r/lP4=
 github.com/mattermost/logr/v2 v2.0.22/go.mod h1:0sUKpO+XNMZApeumaid7PYaUZPBIydfuWZ0dqixXo+s=
+github.com/mattermost/mattermost-plugin-ai v1.3.0 h1:4xPC5PBW+ngmDcmhH4wFbGUw4e1beI8MmyAjlYRjTNI=
+github.com/mattermost/mattermost-plugin-ai v1.3.0/go.mod h1:o47AI97eUomeAf1lnmUJhhoCOVFzw+oVKt4/7AyZxs8=
 github.com/mattermost/mattermost/server/public v0.1.16-0.20250626003732-aaa62a40ae86 h1:LP7+K3hAecJPI6tOfyauRNdfRqk3oV6CDpJLE7XaTc8=
 github.com/mattermost/mattermost/server/public v0.1.16-0.20250626003732-aaa62a40ae86/go.mod h1:EwEPMkzc87/mZYkpi46K0R4fe08HXniPDcpYTB3gv5s=
 github.com/mattermost/xml-roundtrip-validator v0.1.0 h1:RXbVD2UAl7A7nOTR4u7E3ILa4IbtvKBHw64LDsmu9hU=

--- a/plugin.json
+++ b/plugin.json
@@ -39,6 +39,10 @@
                     {
                         "display_name": "Azure AI Content Safety",
                         "value": "azure"
+                    },
+                    {
+                        "display_name": "Mattermost Agents Plugin",
+                        "value": "agents"
                     }
                 ]
             },
@@ -46,7 +50,7 @@
                 "key": "azure_endpoint",
                 "display_name": "Azure API Endpoint",
                 "type": "text",
-                "help_text": "The endpoint URL for the Azure API.",
+                "help_text": "The endpoint URL for the Azure API. (Only required for Azure provider)",
                 "placeholder": "https://your-resource.cognitiveservices.azure.com/"
             },
             {
@@ -54,7 +58,7 @@
                 "display_name": "Azure API Key",
                 "type": "text",
                 "secret": true,
-                "help_text": "Your Azure API key.",
+                "help_text": "Your Azure API key. (Only required for Azure provider)",
                 "placeholder": "Enter your API key here"
             },
             {
@@ -97,7 +101,7 @@
                 "key": "azure_threshold",
                 "display_name": "Azure Moderation Threshold",
                 "type": "dropdown",
-                "help_text": "Severity threshold for all content categories (Low filters most aggressively).",
+                "help_text": "Severity threshold for all content categories (Low filters most aggressively). Only used for Azure provider.",
                 "default": "2",
                 "options": [
                     {
@@ -113,6 +117,42 @@
                         "value": "6"
                     }
                 ]
+            },
+            {
+                "key": "agents_system_prompt",
+                "display_name": "Agents System Prompt",
+                "type": "longtext",
+                "help_text": "The system prompt for the LLM moderation. Leave empty to use default prompt. Only used for Agents provider.",
+                "default": ""
+            },
+            {
+                "key": "agents_threshold",
+                "display_name": "Agents Moderation Threshold",
+                "type": "dropdown",
+                "help_text": "Severity threshold for all content categories (Low filters most aggressively). Only used for Agents provider.",
+                "default": "2",
+                "options": [
+                    {
+                        "display_name": "Low (2)",
+                        "value": "2"
+                    },
+                    {
+                        "display_name": "Medium (4)",
+                        "value": "4"
+                    },
+                    {
+                        "display_name": "High (6)",
+                        "value": "6"
+                    }
+                ]
+            },
+            {
+                "key": "agents_bot_username",
+                "display_name": "Agents Bot Username",
+                "type": "text",
+                "help_text": "The username of the specific agent to use for content moderation. Leave empty to use the default agent. Only used for Agents provider.",
+                "placeholder": "content-moderation-agent",
+                "default": ""
             },
             {
                 "key": "auditLoggingEnabled",

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -58,53 +58,83 @@ func TestConfiguration_ExcludedUserSet(t *testing.T) {
 
 func TestConfiguration_ThresholdValue(t *testing.T) {
 	tests := []struct {
-		name      string
-		threshold string
-		expected  int
-		wantError bool
+		name            string
+		moderatorType   string
+		azureThreshold  string
+		agentsThreshold string
+		expected        int
+		wantError       bool
 	}{
 		{
-			name:      "valid threshold",
-			threshold: "5",
-			expected:  5,
-			wantError: false,
+			name:           "valid azure threshold",
+			moderatorType:  "azure",
+			azureThreshold: "5",
+			expected:       5,
+			wantError:      false,
 		},
 		{
-			name:      "zero threshold",
-			threshold: "0",
-			expected:  0,
-			wantError: false,
+			name:            "valid agents threshold",
+			moderatorType:   "agents",
+			agentsThreshold: "4",
+			expected:        4,
+			wantError:       false,
 		},
 		{
-			name:      "empty threshold",
-			threshold: "",
-			expected:  0,
-			wantError: true,
+			name:           "zero azure threshold",
+			moderatorType:  "azure",
+			azureThreshold: "0",
+			expected:       0,
+			wantError:      false,
 		},
 		{
-			name:      "invalid threshold - not a number",
-			threshold: "abc",
-			expected:  0,
-			wantError: true,
+			name:           "empty azure threshold",
+			moderatorType:  "azure",
+			azureThreshold: "",
+			expected:       0,
+			wantError:      true,
 		},
 		{
-			name:      "invalid threshold - float",
-			threshold: "5.5",
-			expected:  0,
-			wantError: true,
+			name:            "empty agents threshold",
+			moderatorType:   "agents",
+			agentsThreshold: "",
+			expected:        0,
+			wantError:       true,
 		},
 		{
-			name:      "negative threshold",
-			threshold: "-1",
-			expected:  -1,
-			wantError: false,
+			name:           "invalid azure threshold - not a number",
+			moderatorType:  "azure",
+			azureThreshold: "abc",
+			expected:       0,
+			wantError:      true,
+		},
+		{
+			name:           "invalid azure threshold - float",
+			moderatorType:  "azure",
+			azureThreshold: "5.5",
+			expected:       0,
+			wantError:      true,
+		},
+		{
+			name:           "negative azure threshold",
+			moderatorType:  "azure",
+			azureThreshold: "-1",
+			expected:       -1,
+			wantError:      false,
+		},
+		{
+			name:          "unknown moderator type",
+			moderatorType: "unknown",
+			expected:      0,
+			wantError:     true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &configuration{
-				Threshold: tt.threshold,
+				Type:            tt.moderatorType,
+				AzureThreshold:  tt.azureThreshold,
+				AgentsThreshold: tt.agentsThreshold,
 			}
 			result, err := c.ThresholdValue()
 			if tt.wantError {

--- a/server/moderation/agents/agents.go
+++ b/server/moderation/agents/agents.go
@@ -1,0 +1,165 @@
+package agents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-ai/interpluginclient"
+	"github.com/mattermost/mattermost-plugin-content-moderation/server/moderation"
+	"github.com/mattermost/mattermost/server/public/plugin"
+	"github.com/pkg/errors"
+)
+
+const (
+	CategoryHate     = "Hate"
+	CategorySexual   = "Sexual"
+	CategoryViolence = "Violence"
+	CategorySelfHarm = "SelfHarm"
+)
+
+const defaultSystemPrompt = `You are an AI system trained to evaluate user-generated content for safety and policy compliance.
+
+Your task is to assess the message below for the following four categories:
+
+- Hate: Language that expresses, incites, or promotes hatred based on race, religion, gender, sexuality, or similar group identity.
+- SelfHarm: Mentions of self-injury, suicide, or encouragement of self-harm.
+- Sexual: Sexually explicit or suggestive language, including innuendo, erotic descriptions, or references to sexual acts.
+- Violence: Threats, encouragement, or descriptions of physical violence, abuse, or harm.
+
+For each category, assign a severity score using the following scale:
+- 0 — No content of this type
+- 2 — Mild concern
+- 4 — Moderate concern
+- 6 — Severe concern
+
+Respond with a JSON object in **exactly** the following format (no extra commentary):
+
+{
+  "categoriesAnalysis": [
+    {"category": "Hate", "severity": 0},
+    {"category": "SelfHarm", "severity": 0},
+    {"category": "Sexual", "severity": 0},
+    {"category": "Violence", "severity": 0}
+  ]
+}`
+
+var _ moderation.Moderator = (*Moderator)(nil)
+
+type Moderator struct {
+	client       *interpluginclient.Client
+	systemPrompt string
+	api          plugin.API
+	botID        string
+	botUsername  string
+}
+
+type CategoryAnalysis struct {
+	Category string `json:"category"`
+	Severity int    `json:"severity"`
+}
+
+type LLMResponse struct {
+	CategoriesAnalysis []CategoryAnalysis `json:"categoriesAnalysis"`
+}
+
+func New(api plugin.API, systemPrompt string, botID string, botUsername string) (*Moderator, error) {
+	client := interpluginclient.NewClient(&plugin.MattermostPlugin{API: api})
+
+	if err := validateAgentsPlugin(client, api, botID); err != nil {
+		return nil, errors.Wrap(err, "agents plugin not available")
+	}
+
+	if strings.TrimSpace(systemPrompt) == "" {
+		systemPrompt = defaultSystemPrompt
+	}
+
+	return &Moderator{
+		client:       client,
+		systemPrompt: systemPrompt,
+		api:          api,
+		botID:        botID,
+		botUsername:  botUsername,
+	}, nil
+}
+
+func validateAgentsPlugin(client *interpluginclient.Client, api plugin.API, botID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	response, err := client.SimpleCompletionWithContext(ctx, interpluginclient.SimpleCompletionRequest{
+		SystemPrompt:    "Test connection",
+		UserPrompt:      "Respond with 'OK'",
+		RequesterUserID: botID,
+	})
+
+	if response != "OK" || err != nil {
+		return errors.Wrap(err, "agents plugin connection test failed")
+	}
+
+	return nil
+}
+
+func (m *Moderator) ModerateText(ctx context.Context, text string) (moderation.Result, error) {
+	req := interpluginclient.SimpleCompletionRequest{
+		SystemPrompt:    m.systemPrompt,
+		UserPrompt:      fmt.Sprintf("Message: %q", text),
+		RequesterUserID: m.botID,
+		BotUsername:     m.botUsername,
+	}
+
+	response, err := m.client.SimpleCompletionWithContext(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get LLM response from agents plugin")
+	}
+
+	result, err := m.parseStructuredResponse(response)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse LLM response")
+	}
+
+	return result, nil
+}
+
+func (m *Moderator) parseStructuredResponse(response string) (moderation.Result, error) {
+	jsonStart := strings.Index(response, "{")
+	jsonEnd := strings.LastIndex(response, "}")
+	if jsonStart == -1 || jsonEnd == -1 || jsonEnd <= jsonStart {
+		return nil, errors.New("no JSON block found in response")
+	}
+	jsonStr := response[jsonStart : jsonEnd+1]
+
+	var llmResponse LLMResponse
+	if err := json.Unmarshal([]byte(jsonStr), &llmResponse); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal JSON response")
+	}
+
+	if len(llmResponse.CategoriesAnalysis) == 0 {
+		return nil, errors.New("received empty analysis in JSON response")
+	}
+
+	result := make(moderation.Result)
+	for _, categoryResult := range llmResponse.CategoriesAnalysis {
+		if err := m.validateSeverity(categoryResult.Severity); err != nil {
+			return nil, fmt.Errorf("%w: category=%s, severity=%d",
+				err, categoryResult.Category, categoryResult.Severity)
+		}
+		result[categoryResult.Category] = categoryResult.Severity
+	}
+
+	return result, nil
+}
+
+func (m *Moderator) validateSeverity(severity int) error {
+	switch severity {
+	case 0:
+	case 2:
+	case 4:
+	case 6:
+	default:
+		return errors.New("invalid severity value")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds the Mattermost Agents Plugin as a second backend option for content moderation, alongside the existing Azure AI Content Safety integration. Users can now select between "Azure AI Content Safety" and "Mattermost Agents Plugin" via a dropdown in the plugin configuration.

## Implementation

- **New Backend**: `server/moderation/agents/agents.go` implements the `Moderator` interface using the AI plugin's `interpluginclient`
- **Configuration**: Added `Type` field with dropdown selection and agents-specific settings (`AgentsSystemPrompt`, `AgentsThreshold`)
- **LLM Integration**: Uses structured JSON responses with the same 0/2/4/6 severity scale across four categories (Hate, Sexual, Violence, SelfHarm)
- **Validation**: Connection testing during initialization ensures the Agents Plugin is properly configured
- **Customization**: Configurable system prompt with a default prompt, adjustable thresholds for agent requests, and specific agent selection via bot username

## Technical Details

The agents backend sends structured prompts to the LLM via the AI plugin's simple completion API and parses JSON responses for severity scoring. The implementation maintains the existing fail-open approach and error handling patterns.

Configuration is backward compatible - existing Azure setups continue to work unchanged.

## Future Enhancements

- **System Prompt Refinement**: The current default prompt is a good starting point, but will need tweaking based on testing results. A prompt-focused improvement PR will follow.
- **Dynamic Configuration**: All backend-specific config options are currently displayed at all times. They should only display when the relevant backend type is selected (e.g., Azure options only show when Azure is selected).