### PR TITLE
Refactor configuration to show only relevant provider settings

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -30,36 +30,26 @@
                 "default": false
             },
             {
-                "key": "type",
-                "display_name": "Moderation Provider",
-                "type": "dropdown",
-                "help_text": "Select which content moderation provider to use.",
-                "default": "azure",
-                "options": [
-                    {
-                        "display_name": "Azure AI Content Safety",
-                        "value": "azure"
-                    },
-                    {
-                        "display_name": "Mattermost Agents Plugin",
-                        "value": "agents"
-                    }
-                ]
+                "key": "botUsername",
+                "display_name": "Bot Username",
+                "type": "text",
+                "help_text": "The username that will be displayed for moderation notifications.",
+                "placeholder": "content-moderation-bot",
+                "default": "content-moderation-bot"
             },
             {
-                "key": "azure_endpoint",
-                "display_name": "Azure API Endpoint",
+                "key": "botDisplayName",
+                "display_name": "Bot Display Name",
                 "type": "text",
-                "help_text": "The endpoint URL for the Azure API. (Only required for Azure provider)",
-                "placeholder": "https://your-resource.cognitiveservices.azure.com/"
+                "help_text": "The display name that will be shown for the moderation bot.",
+                "placeholder": "Content Moderation Bot",
+                "default": "Content Moderation Bot"
             },
             {
-                "key": "azure_apiKey",
-                "display_name": "Azure API Key",
-                "type": "text",
-                "secret": true,
-                "help_text": "Your Azure API key. (Only required for Azure provider)",
-                "placeholder": "Enter your API key here"
+                "key": "moderatorConfig",
+                "display_name": "Provider Configuration",
+                "type": "custom",
+                "help_text": "Configuration specific to the selected moderation provider."
             },
             {
                 "key": "excludeDirectMessages",
@@ -82,79 +72,6 @@
                 "help_text": "Users to exclude from content moderation. All others will be moderated."
             },
             {
-                "key": "botUsername",
-                "display_name": "Bot Username",
-                "type": "text",
-                "help_text": "The username that will be displayed for moderation notifications.",
-                "placeholder": "content-moderation-bot",
-                "default": "content-moderation-bot"
-            },
-            {
-                "key": "botDisplayName",
-                "display_name": "Bot Display Name",
-                "type": "text",
-                "help_text": "The display name that will be shown for the moderation bot.",
-                "placeholder": "Content Moderation Bot",
-                "default": "Content Moderation Bot"
-            },
-            {
-                "key": "azure_threshold",
-                "display_name": "Azure Moderation Threshold",
-                "type": "dropdown",
-                "help_text": "Severity threshold for all content categories (Low filters most aggressively). Only used for Azure provider.",
-                "default": "2",
-                "options": [
-                    {
-                        "display_name": "Low (2)",
-                        "value": "2"
-                    },
-                    {
-                        "display_name": "Medium (4)",
-                        "value": "4"
-                    },
-                    {
-                        "display_name": "High (6)",
-                        "value": "6"
-                    }
-                ]
-            },
-            {
-                "key": "agents_system_prompt",
-                "display_name": "Agents System Prompt",
-                "type": "longtext",
-                "help_text": "The system prompt for the LLM moderation. Leave empty to use default prompt. Only used for Agents provider.",
-                "default": ""
-            },
-            {
-                "key": "agents_threshold",
-                "display_name": "Agents Moderation Threshold",
-                "type": "dropdown",
-                "help_text": "Severity threshold for all content categories (Low filters most aggressively). Only used for Agents provider.",
-                "default": "2",
-                "options": [
-                    {
-                        "display_name": "Low (2)",
-                        "value": "2"
-                    },
-                    {
-                        "display_name": "Medium (4)",
-                        "value": "4"
-                    },
-                    {
-                        "display_name": "High (6)",
-                        "value": "6"
-                    }
-                ]
-            },
-            {
-                "key": "agents_bot_username",
-                "display_name": "Agents Bot Username",
-                "type": "text",
-                "help_text": "The username of the specific agent to use for content moderation. Leave empty to use the default agent. Only used for Agents provider.",
-                "placeholder": "content-moderation-agent",
-                "default": ""
-            },
-            {
                 "key": "auditLoggingEnabled",
                 "display_name": "Enable Audit Logging",
                 "type": "bool",
@@ -165,7 +82,7 @@
                 "key": "rateLimitPerMinute",
                 "display_name": "Rate Limit (requests per minute)",
                 "type": "number",
-                "help_text": "Maximum number of moderation API requests per minute. Default is 500 for Azure AI Content Safety.",
+                "help_text": "Maximum number of moderation API requests per minute. Default is 500.",
                 "default": 500
             }
         ]

--- a/server/configuration_test.go
+++ b/server/configuration_test.go
@@ -132,9 +132,11 @@ func TestConfiguration_ThresholdValue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &configuration{
-				Type:            tt.moderatorType,
-				AzureThreshold:  tt.azureThreshold,
-				AgentsThreshold: tt.agentsThreshold,
+				ModeratorConfig: ModeratorConfig{
+					Type:            tt.moderatorType,
+					AzureThreshold:  tt.azureThreshold,
+					AgentsThreshold: tt.agentsThreshold,
+				},
 			}
 			result, err := c.ThresholdValue()
 			if tt.wantError {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -119,11 +119,11 @@ func (p *Plugin) initialize(config *configuration) error {
 }
 
 func initModerator(api plugin.API, config *configuration, pluginBotID string) (moderation.Moderator, error) {
-	switch config.Type {
+	switch config.ModeratorConfig.Type {
 	case "azure":
 		azureConfig := &moderation.Config{
-			Endpoint: config.AzureEndpoint,
-			APIKey:   config.AzureAPIKey,
+			Endpoint: config.ModeratorConfig.AzureEndpoint,
+			APIKey:   config.ModeratorConfig.AzureAPIKey,
 		}
 
 		mod, err := azure.New(azureConfig)
@@ -134,7 +134,7 @@ func initModerator(api plugin.API, config *configuration, pluginBotID string) (m
 		api.LogInfo("Azure AI Content Safety moderator initialized")
 		return mod, nil
 	case "agents":
-		mod, err := agents.New(api, config.AgentsSystemPrompt, pluginBotID, config.AgentsBotUsername)
+		mod, err := agents.New(api, config.ModeratorConfig.AgentsSystemPrompt, pluginBotID, config.ModeratorConfig.AgentsBotUsername)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create agents moderator")
 		}
@@ -142,6 +142,6 @@ func initModerator(api plugin.API, config *configuration, pluginBotID string) (m
 		api.LogInfo("Agents plugin moderator initialized")
 		return mod, nil
 	default:
-		return nil, errors.Errorf("unknown moderator type: %s", config.Type)
+		return nil, errors.Errorf("unknown moderator type: %s", config.ModeratorConfig.Type)
 	}
 }

--- a/webapp/src/components/admin_settings/agents_constants.ts
+++ b/webapp/src/components/admin_settings/agents_constants.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export const DEFAULT_AGENTS_SYSTEM_PROMPT = `You are an AI system trained to evaluate user-generated content for safety and policy compliance.
+
+Your task is to assess the message below for the following four categories:
+
+- Hate: Language that expresses, incites, or promotes hatred based on race, religion, gender, sexuality, or similar group identity.
+- SelfHarm: Mentions of self-injury, suicide, or encouragement of self-harm.
+- Sexual: Sexually explicit or suggestive language, including innuendo, erotic descriptions, or references to sexual acts.
+- Violence: Threats, encouragement, or descriptions of physical violence, abuse, or harm.
+
+For each category, assign a severity score using the following scale:
+- 0 — No content of this type
+- 2 — Mild concern
+- 4 — Moderate concern
+- 6 — Severe concern
+
+Respond with a JSON object in **exactly** the following format (no extra commentary):
+
+{
+  "categoriesAnalysis": [
+    {"category": "Hate", "severity": 0},
+    {"category": "SelfHarm", "severity": 0},
+    {"category": "Sexual", "severity": 0},
+    {"category": "Violence", "severity": 0}
+  ]
+}`;

--- a/webapp/src/components/admin_settings/moderator_config.tsx
+++ b/webapp/src/components/admin_settings/moderator_config.tsx
@@ -1,0 +1,410 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useState, useEffect, useCallback} from 'react';
+
+import {DEFAULT_AGENTS_SYSTEM_PROMPT} from '@/components/admin_settings/agents_constants';
+
+type ModeratorType = 'azure' | 'agents';
+
+const THRESHOLD_OPTIONS = [
+    {value: '2', label: 'Low (2)'},
+    {value: '4', label: 'Medium (4)'},
+    {value: '6', label: 'High (6)'},
+] as const;
+
+interface ModeratorConfigValue {
+    type: ModeratorType;
+    azure_endpoint?: string;
+    azure_apiKey?: string;
+    azure_threshold?: string;
+    agents_system_prompt?: string;
+    agents_threshold?: string;
+    agents_bot_username?: string;
+}
+
+interface ModeratorConfigProps {
+    id: string;
+    value?: ModeratorConfigValue;
+    onChange: (id: string, value: ModeratorConfigValue) => void;
+    settings: Record<string, unknown>;
+    config?: Record<string, unknown>;
+}
+
+// Helper function to create default configuration values
+const createDefaultConfig = (type: ModeratorType = 'agents', existingValues?: Partial<ModeratorConfigValue>): ModeratorConfigValue => {
+    const defaults: ModeratorConfigValue = {
+        type,
+        azure_endpoint: '',
+        azure_apiKey: '',
+        azure_threshold: THRESHOLD_OPTIONS[0].value, // '2'
+        agents_system_prompt: DEFAULT_AGENTS_SYSTEM_PROMPT,
+        agents_threshold: THRESHOLD_OPTIONS[0].value, // '2'
+        agents_bot_username: '',
+        ...existingValues,
+    };
+    return defaults;
+};
+
+const ModeratorConfig: React.FC<ModeratorConfigProps> = ({id, value, onChange}) => {
+    // Initialize with clean defaults, using any provided values
+    const initialConfig = createDefaultConfig(value?.type, value);
+    const [currentType, setCurrentType] = useState<ModeratorType>(initialConfig.type);
+    const [values, setValues] = useState<ModeratorConfigValue>(initialConfig);
+
+    // Update state when props change
+    useEffect(() => {
+        if (value && JSON.stringify(value) !== JSON.stringify(values)) {
+            const newValues = createDefaultConfig(value.type, value);
+            setCurrentType(newValues.type);
+            setValues(newValues);
+        }
+    }, [value]);
+
+    // Notify parent of initial values on component mount
+    useEffect(() => {
+        if (!value) {
+            onChange(id, initialConfig);
+        }
+    }, [value, onChange, id, initialConfig]);
+
+    // Memoized field change handler to prevent unnecessary re-renders
+    const handleFieldChange = useCallback((field: keyof ModeratorConfigValue, fieldValue: string) => {
+        let newValues: ModeratorConfigValue;
+
+        if (field === 'type') {
+            // When switching type, merge with appropriate defaults for the new type
+            newValues = createDefaultConfig(fieldValue as ModeratorType, values);
+            setCurrentType(fieldValue as ModeratorType);
+        } else {
+            newValues = {
+                ...values,
+                [field]: fieldValue,
+            };
+        }
+
+        setValues(newValues);
+        onChange(id, newValues);
+    }, [values, onChange, id]);
+
+    // Memoized render functions to prevent unnecessary re-renders
+    const renderAzureSettings = useCallback((settings: ModeratorConfigValue) => {
+        const azureEndpoint = settings.azure_endpoint || '';
+        const azureApiKey = settings.azure_apiKey || '';
+        const azureThreshold = settings.azure_threshold || '2';
+
+        return (
+            <>
+                <div style={{marginBottom: '16px'}}>
+                    <label
+                        style={{
+                            display: 'block',
+                            marginBottom: '8px',
+                            color: '#3f4350',
+                            fontSize: '14px',
+                            fontWeight: '600',
+                        }}
+                    >
+                        {'Azure API Endpoint'}
+                    </label>
+                    <input
+                        type='text'
+                        value={azureEndpoint}
+                        onChange={(e) => handleFieldChange('azure_endpoint', e.target.value)}
+                        placeholder='https://your-resource.cognitiveservices.azure.com/'
+                        style={{
+                            width: '100%',
+                            padding: '8px 12px',
+                            border: '1px solid #d1d5db',
+                            borderRadius: '4px',
+                            fontSize: '14px',
+                            boxSizing: 'border-box',
+                        }}
+                    />
+                    <p
+                        style={{
+                            marginTop: '4px',
+                            marginBottom: '0',
+                            color: '#6b7280',
+                            fontSize: '12px',
+                        }}
+                    >
+                        {'The endpoint URL for the Azure AI Content Safety API.'}
+                    </p>
+                </div>
+
+                <div style={{marginBottom: '16px'}}>
+                    <label
+                        style={{
+                            display: 'block',
+                            marginBottom: '8px',
+                            color: '#3f4350',
+                            fontSize: '14px',
+                            fontWeight: '600',
+                        }}
+                    >
+                        {'Azure API Key'}
+                    </label>
+                    <input
+                        type='password'
+                        value={azureApiKey}
+                        onChange={(e) => handleFieldChange('azure_apiKey', e.target.value)}
+                        placeholder='Enter your Azure API key'
+                        style={{
+                            width: '100%',
+                            padding: '8px 12px',
+                            border: '1px solid #d1d5db',
+                            borderRadius: '4px',
+                            fontSize: '14px',
+                            boxSizing: 'border-box',
+                        }}
+                    />
+                    <p
+                        style={{
+                            marginTop: '4px',
+                            marginBottom: '0',
+                            color: '#6b7280',
+                            fontSize: '12px',
+                        }}
+                    >
+                        {'Your Azure AI Content Safety API key.'}
+                    </p>
+                </div>
+
+                <div>
+                    <label
+                        style={{
+                            display: 'block',
+                            marginBottom: '8px',
+                            color: '#3f4350',
+                            fontSize: '14px',
+                            fontWeight: '600',
+                        }}
+                    >
+                        {'Moderation Threshold'}
+                    </label>
+                    <select
+                        value={azureThreshold}
+                        onChange={(e) => handleFieldChange('azure_threshold', e.target.value)}
+                        style={{
+                            width: '100%',
+                            padding: '8px 12px',
+                            border: '1px solid #d1d5db',
+                            borderRadius: '4px',
+                            fontSize: '14px',
+                            boxSizing: 'border-box',
+                        }}
+                    >
+                        {THRESHOLD_OPTIONS.map((option) => (
+                            <option
+                                key={option.value}
+                                value={option.value}
+                            >
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                    <p
+                        style={{
+                            marginTop: '4px',
+                            marginBottom: '0',
+                            color: '#6b7280',
+                            fontSize: '12px',
+                        }}
+                    >
+                        {'Severity threshold for all content categories (Low filters most aggressively).'}
+                    </p>
+                </div>
+            </>
+        );
+    }, [handleFieldChange]);
+
+    const renderAgentsSettings = useCallback((settings: ModeratorConfigValue) => {
+        const agentsSystemPrompt = settings.agents_system_prompt || '';
+        const agentsThreshold = settings.agents_threshold || '2';
+        const agentsBotUsername = settings.agents_bot_username || '';
+
+        return (
+            <>
+                <div style={{marginBottom: '16px'}}>
+                    <label
+                        style={{
+                            display: 'block',
+                            marginBottom: '8px',
+                            color: '#3f4350',
+                            fontSize: '14px',
+                            fontWeight: '600',
+                        }}
+                    >
+                        {'Agent Bot Username'}
+                    </label>
+                    <input
+                        type='text'
+                        value={agentsBotUsername}
+                        onChange={(e) => handleFieldChange('agents_bot_username', e.target.value)}
+                        placeholder='content-moderation-agent'
+                        style={{
+                            width: '100%',
+                            padding: '8px 12px',
+                            border: '1px solid #d1d5db',
+                            borderRadius: '4px',
+                            fontSize: '14px',
+                            boxSizing: 'border-box',
+                        }}
+                    />
+                    <p
+                        style={{
+                            marginTop: '4px',
+                            marginBottom: '0',
+                            color: '#6b7280',
+                            fontSize: '12px',
+                        }}
+                    >
+                        {'Username of the specific agent to use for content moderation. Leave empty to use the default agent.'}
+                    </p>
+                </div>
+
+                <div style={{marginBottom: '16px'}}>
+                    <label
+                        style={{
+                            display: 'block',
+                            marginBottom: '8px',
+                            color: '#3f4350',
+                            fontSize: '14px',
+                            fontWeight: '600',
+                        }}
+                    >
+                        {'System Prompt'}
+                    </label>
+                    <textarea
+                        value={agentsSystemPrompt}
+                        onChange={(e) => handleFieldChange('agents_system_prompt', e.target.value)}
+                        placeholder='Default prompt will be used when empty'
+                        rows={4}
+                        style={{
+                            width: '100%',
+                            padding: '8px 12px',
+                            border: '1px solid #d1d5db',
+                            borderRadius: '4px',
+                            fontSize: '14px',
+                            boxSizing: 'border-box',
+                            resize: 'vertical',
+                        }}
+                    />
+                    <p
+                        style={{
+                            marginTop: '4px',
+                            marginBottom: '0',
+                            color: '#6b7280',
+                            fontSize: '12px',
+                        }}
+                    >
+                        {'Custom system prompt for the LLM moderation. The default prompt will be used when this field is empty.'}
+                    </p>
+                </div>
+
+                <div>
+                    <label
+                        style={{
+                            display: 'block',
+                            marginBottom: '8px',
+                            color: '#3f4350',
+                            fontSize: '14px',
+                            fontWeight: '600',
+                        }}
+                    >
+                        {'Moderation Threshold'}
+                    </label>
+                    <select
+                        value={agentsThreshold}
+                        onChange={(e) => handleFieldChange('agents_threshold', e.target.value)}
+                        style={{
+                            width: '100%',
+                            padding: '8px 12px',
+                            border: '1px solid #d1d5db',
+                            borderRadius: '4px',
+                            fontSize: '14px',
+                            boxSizing: 'border-box',
+                        }}
+                    >
+                        {THRESHOLD_OPTIONS.map((option) => (
+                            <option
+                                key={option.value}
+                                value={option.value}
+                            >
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                    <p
+                        style={{
+                            marginTop: '4px',
+                            marginBottom: '0',
+                            color: '#6b7280',
+                            fontSize: '12px',
+                        }}
+                    >
+                        {'Severity threshold for all content categories (Low filters most aggressively).'}
+                    </p>
+                </div>
+            </>
+        );
+    }, [handleFieldChange]);
+
+    return (
+        <div
+            style={{
+                border: '1px solid #e6e6e6',
+                borderRadius: '4px',
+                padding: '24px 16px',
+                marginBottom: '24px',
+                backgroundColor: '#f9f9f9',
+            }}
+        >
+
+            <div style={{marginBottom: '24px'}}>
+                <label
+                    style={{
+                        display: 'block',
+                        marginBottom: '8px',
+                        color: '#3f4350',
+                        fontSize: '14px',
+                        fontWeight: '600',
+                    }}
+                >
+                    {'Moderation Provider'}
+                </label>
+                <select
+                    value={currentType}
+                    onChange={(e) => handleFieldChange('type', e.target.value)}
+                    style={{
+                        width: '100%',
+                        padding: '8px 12px',
+                        border: '1px solid #d1d5db',
+                        borderRadius: '4px',
+                        fontSize: '14px',
+                        boxSizing: 'border-box',
+                    }}
+                >
+                    <option value='azure'>{'Azure AI Content Safety'}</option>
+                    <option value='agents'>{'Mattermost Agents Plugin'}</option>
+                </select>
+                <p
+                    style={{
+                        marginTop: '4px',
+                        marginBottom: '0',
+                        color: '#6b7280',
+                        fontSize: '12px',
+                    }}
+                >
+                    {'Select which content moderation provider to use.'}
+                </p>
+            </div>
+
+            {currentType === 'azure' && renderAzureSettings(values)}
+            {currentType === 'agents' && renderAgentsSettings(values)}
+        </div>
+    );
+};
+
+export default ModeratorConfig;

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -4,6 +4,7 @@
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import {client} from '@/client';
+import ModeratorConfig from '@/components/admin_settings/moderator_config';
 import UserSettings from '@/components/admin_settings/user_settings';
 import manifest from '@/manifest';
 import type {PluginRegistry} from '@/types/mattermost-webapp';
@@ -14,6 +15,7 @@ export default class Plugin {
     public async initialize(registry: PluginRegistry, store: any) {
         this.store = store;
         registry.registerAdminConsoleCustomSetting('excludedUsers', UserSettings, {showTitle: true});
+        registry.registerAdminConsoleCustomSetting('moderatorConfig', ModeratorConfig, {showTitle: false});
 
         registry.registerChannelHeaderMenuAction(
             'Enable Channel Moderation',


### PR DESCRIPTION
Moves Azure and Agents moderator settings into a custom component that only displays provider-specific options when that provider type is selected. This improves the user experience by reducing configuration complexity and preventing confusion from irrelevant settings.

Also address a few edge cases where an LLM could return JSON with comments or with odd severity numbers between 0 and 6.

<img width="942" height="493" alt="Screenshot from 2025-08-08 16-50-27" src="https://github.com/user-attachments/assets/a5320f8a-51ef-4eff-8196-59655ac3bbbf" />
<img width="938" height="559" alt="Screenshot from 2025-08-08 16-50-17" src="https://github.com/user-attachments/assets/54c28009-edec-422b-a39b-e366802e1741" />
